### PR TITLE
Fix simple typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                     <thead>
                         <tr>
                             <th>Name</th>
-                            <th>Descrition</th>
+                            <th>Description</th>
                             <th>Version</th>
                             <th>License</th>
                             <th></th>


### PR DESCRIPTION
Fix "Descrition" -> "Description" 🙂 